### PR TITLE
Notification instead of Modal for succes or error

### DIFF
--- a/lib/progress-element.coffee
+++ b/lib/progress-element.coffee
@@ -10,20 +10,6 @@ class ProgressElement extends HTMLDivElement
       </span>
     """
 
-  displaySuccess: ->
-    @innerHTML = """
-      <span class="text-success">
-        Package dependencies updated.
-      </span>
-    """
-
-  displayFailure: ->
-    @innerHTML = """
-      <span class="text-error">
-        Failed to update package dependencies.
-      </span>
-    """
-
 module.exports =
 document.registerElement("update-package-dependencies-progress",
   prototype: ProgressElement.prototype

--- a/lib/update-package-dependencies.coffee
+++ b/lib/update-package-dependencies.coffee
@@ -22,8 +22,10 @@ module.exports =
         panel.destroy()
 
       if code is 0
+        atom.notifications.addSuccess("Package dependencies updated.")
         view.displaySuccess()
       else
+        atom.notifications.addError("Failed to update package dependencies.")
         view.displayFailure()
 
     @runBufferedProcess({command, args, exit, options})

--- a/lib/update-package-dependencies.coffee
+++ b/lib/update-package-dependencies.coffee
@@ -22,7 +22,7 @@ module.exports =
         panel.destroy()
 
       if code is 0
-        atom.notifications.addSuccess("Succes!", detail: "Package dependencies updated.")
+        atom.notifications.addSuccess("Success!", detail: "Package dependencies updated.")
         panel.destroy()
       else
         atom.notifications.addError("Error!", detail: "Failed to update package dependencies.")

--- a/lib/update-package-dependencies.coffee
+++ b/lib/update-package-dependencies.coffee
@@ -22,10 +22,10 @@ module.exports =
         panel.destroy()
 
       if code is 0
-        atom.notifications.addSuccess("Package dependencies updated.")
+        atom.notifications.addSuccess("Succes!", detail: "Package dependencies updated.")
         panel.destroy()
       else
-        atom.notifications.addError("Failed to update package dependencies.")
+        atom.notifications.addError("Error!", detail: "Failed to update package dependencies.")
         panel.destroy()
 
     @runBufferedProcess({command, args, exit, options})

--- a/lib/update-package-dependencies.coffee
+++ b/lib/update-package-dependencies.coffee
@@ -23,10 +23,10 @@ module.exports =
 
       if code is 0
         atom.notifications.addSuccess("Package dependencies updated.")
-        view.displaySuccess()
+        panel.destroy()
       else
         atom.notifications.addError("Failed to update package dependencies.")
-        view.displayFailure()
+        panel.destroy()
 
     @runBufferedProcess({command, args, exit, options})
 

--- a/spec/update-package-dependencies-spec.coffee
+++ b/spec/update-package-dependencies-spec.coffee
@@ -56,7 +56,7 @@ describe "Update Package Dependencies", ->
       it "shows a success notification message", ->
         [notifications] = atom.notifications.getNotifications()
         expect(atom.workspace.getModalPanels().length).toEqual(0)
-        expect(atom.notifications.getNotifications()[0].getMessage()).toEqual("Succes!")
+        expect(atom.notifications.getNotifications()[0].getMessage()).toEqual("Success!")
 
     describe "when the update fails", ->
       beforeEach ->

--- a/spec/update-package-dependencies-spec.coffee
+++ b/spec/update-package-dependencies-spec.coffee
@@ -54,9 +54,10 @@ describe "Update Package Dependencies", ->
         exit(0)
 
       it "shows a success notification message", ->
-        [notifications] = atom.notifications.getNotifications()
+        [notification] = atom.notifications.getNotifications()
         expect(atom.workspace.getModalPanels().length).toEqual(0)
-        expect(atom.notifications.getNotifications()[0].getMessage()).toEqual("Success!")
+        expect(notification.getType()).toEqual("success")
+        expect(notification.getMessage()).toEqual("Success!")
 
     describe "when the update fails", ->
       beforeEach ->
@@ -65,7 +66,7 @@ describe "Update Package Dependencies", ->
         exit(127)
 
       it "shows a failure message in the modal", ->
-        [modal] = atom.workspace.getModalPanels()
-        [notifications] = atom.notifications.getNotifications()
+        [notification] = atom.notifications.getNotifications()
         expect(atom.workspace.getModalPanels().length).toEqual(0)
-        expect(atom.notifications.getNotifications()[0].getMessage()).toEqual("Error!")
+        expect(notification.getType()).toEqual("error")
+        expect(notification.getMessage()).toEqual("Error!")

--- a/spec/update-package-dependencies-spec.coffee
+++ b/spec/update-package-dependencies-spec.coffee
@@ -53,16 +53,10 @@ describe "Update Package Dependencies", ->
         [{exit}] = mainModule.runBufferedProcess.argsForCall[0]
         exit(0)
 
-      it "shows a success message in the modal", ->
-        [modal] = atom.workspace.getModalPanels()
-        expect(modal.getItem().querySelector(".loading")).toBeNull()
-        expect(modal.getItem().textContent).toMatch(/Package dependencies updated/)
-
-      describe "triggering core:cancel", ->
-        it "dismisses the modal", ->
-          [modal] = atom.workspace.getModalPanels()
-          atom.commands.dispatch(modal.getItem(), 'core:cancel')
-          expect(atom.workspace.getModalPanels().length).toBe(0)
+      it "shows a success notification message", ->
+        [notifications] = atom.notifications.getNotifications()
+        expect(atom.workspace.getModalPanels().length).toEqual(0)
+        expect(atom.notifications.getNotifications()[0].getMessage()).toEqual("Succes!")
 
     describe "when the update fails", ->
       beforeEach ->
@@ -72,5 +66,6 @@ describe "Update Package Dependencies", ->
 
       it "shows a failure message in the modal", ->
         [modal] = atom.workspace.getModalPanels()
-        expect(modal.getItem().querySelector(".loading")).toBeNull()
-        expect(modal.getItem().textContent).toMatch(/Failed to update package dependencies/)
+        [notifications] = atom.notifications.getNotifications()
+        expect(atom.workspace.getModalPanels().length).toEqual(0)
+        expect(atom.notifications.getNotifications()[0].getMessage()).toEqual("Error!")


### PR DESCRIPTION
Hello, i found a bit cumbersome modals for succes and errors because removing the modal isn't  intuitive enought.

The new specs are all green, feel free to ask for corrections.

Thanks

Jaga

![selezione_001](https://cloud.githubusercontent.com/assets/4562878/9115422/4a70d376-3c5f-11e5-955e-8d131518f0ed.png)
![selezione_002](https://cloud.githubusercontent.com/assets/4562878/9115423/4a77b7ae-3c5f-11e5-850d-a35b48bed12b.png)
