### PR TITLE
Remove custom elements

### DIFF
--- a/lib/progress-element.coffee
+++ b/lib/progress-element.coffee
@@ -1,9 +1,11 @@
-class ProgressElement extends HTMLDivElement
-  createdCallback: ->
-    @tabIndex = -1
+module.exports =
+class ProgressElement
+  constructor: ->
+    @element = document.createElement("update-package-dependencies-progress")
+    @element.tabIndex = -1
 
   displayLoading: ->
-    @innerHTML = """
+    @element.innerHTML = """
       <span class="loading loading-spinner-small inline-block"></span>
       <span>
         Updating package dependencies\u2026
@@ -11,21 +13,15 @@ class ProgressElement extends HTMLDivElement
     """
 
   displaySuccess: ->
-    @innerHTML = """
+    @element.innerHTML = """
       <span class="text-success">
         Package dependencies updated.
       </span>
     """
 
   displayFailure: ->
-    @innerHTML = """
+    @element.innerHTML = """
       <span class="text-error">
         Failed to update package dependencies.
       </span>
     """
-
-module.exports =
-document.registerElement("update-package-dependencies-progress",
-  prototype: ProgressElement.prototype
-  extends: "div"
-)

--- a/lib/update-package-dependencies.coffee
+++ b/lib/update-package-dependencies.coffee
@@ -16,9 +16,9 @@ module.exports =
     options = {cwd: @getActiveProjectPath()}
 
     exit = (code) ->
-      view.focus()
+      view.element.focus()
 
-      atom.commands.add view, 'core:cancel', ->
+      atom.commands.add view.element, 'core:cancel', ->
         panel.destroy()
 
       if code is 0

--- a/spec/update-package-dependencies-spec.coffee
+++ b/spec/update-package-dependencies-spec.coffee
@@ -31,8 +31,8 @@ describe "Update Package Dependencies", ->
       atom.commands.dispatch(workspaceElement, "update-package-dependencies:update")
 
       [modal] = atom.workspace.getModalPanels()
-      expect(modal.getItem().querySelector(".loading")).not.toBeNull()
-      expect(modal.getItem().textContent).toMatch(/Updating package dependencies/)
+      expect(modal.getItem().element.querySelector(".loading")).not.toBeNull()
+      expect(modal.getItem().element.textContent).toMatch(/Updating package dependencies/)
 
     describe "when there are multiple project paths", ->
       beforeEach ->
@@ -55,13 +55,13 @@ describe "Update Package Dependencies", ->
 
       it "shows a success message in the modal", ->
         [modal] = atom.workspace.getModalPanels()
-        expect(modal.getItem().querySelector(".loading")).toBeNull()
-        expect(modal.getItem().textContent).toMatch(/Package dependencies updated/)
+        expect(modal.getItem().element.querySelector(".loading")).toBeNull()
+        expect(modal.getItem().element.textContent).toMatch(/Package dependencies updated/)
 
       describe "triggering core:cancel", ->
         it "dismisses the modal", ->
           [modal] = atom.workspace.getModalPanels()
-          atom.commands.dispatch(modal.getItem(), 'core:cancel')
+          atom.commands.dispatch(modal.getItem().element, 'core:cancel')
           expect(atom.workspace.getModalPanels().length).toBe(0)
 
     describe "when the update fails", ->
@@ -72,5 +72,5 @@ describe "Update Package Dependencies", ->
 
       it "shows a failure message in the modal", ->
         [modal] = atom.workspace.getModalPanels()
-        expect(modal.getItem().querySelector(".loading")).toBeNull()
-        expect(modal.getItem().textContent).toMatch(/Failed to update package dependencies/)
+        expect(modal.getItem().element.querySelector(".loading")).toBeNull()
+        expect(modal.getItem().element.textContent).toMatch(/Failed to update package dependencies/)


### PR DESCRIPTION
This pull request stops registering custom elements during startup and uses a simple javascript object that internally manages a DOM element instead.

/cc: @ungb for 👀