### PR TITLE
Resolve merge conflicts with #9 (use notification for success or error)

### DIFF
--- a/lib/progress-element.coffee
+++ b/lib/progress-element.coffee
@@ -11,17 +11,3 @@ class ProgressElement
         Updating package dependencies\u2026
       </span>
     """
-
-  displaySuccess: ->
-    @element.innerHTML = """
-      <span class="text-success">
-        Package dependencies updated.
-      </span>
-    """
-
-  displayFailure: ->
-    @element.innerHTML = """
-      <span class="text-error">
-        Failed to update package dependencies.
-      </span>
-    """

--- a/lib/update-package-dependencies.coffee
+++ b/lib/update-package-dependencies.coffee
@@ -22,9 +22,11 @@ module.exports =
         panel.destroy()
 
       if code is 0
-        view.displaySuccess()
+        atom.notifications.addSuccess("Success!", detail: "Package dependencies updated.")
+        panel.destroy()
       else
-        view.displayFailure()
+        atom.notifications.addError("Error!", detail: "Failed to update package dependencies.")
+        panel.destroy()
 
     @runBufferedProcess({command, args, exit, options})
 

--- a/spec/update-package-dependencies-spec.coffee
+++ b/spec/update-package-dependencies-spec.coffee
@@ -53,16 +53,11 @@ describe "Update Package Dependencies", ->
         [{exit}] = mainModule.runBufferedProcess.argsForCall[0]
         exit(0)
 
-      it "shows a success message in the modal", ->
-        [modal] = atom.workspace.getModalPanels()
-        expect(modal.getItem().element.querySelector(".loading")).toBeNull()
-        expect(modal.getItem().element.textContent).toMatch(/Package dependencies updated/)
-
-      describe "triggering core:cancel", ->
-        it "dismisses the modal", ->
-          [modal] = atom.workspace.getModalPanels()
-          atom.commands.dispatch(modal.getItem().element, 'core:cancel')
-          expect(atom.workspace.getModalPanels().length).toBe(0)
+      it "shows a success notification message", ->
+        [notification] = atom.notifications.getNotifications()
+        expect(atom.workspace.getModalPanels().length).toEqual(0)
+        expect(notification.getType()).toEqual("success")
+        expect(notification.getMessage()).toEqual("Success!")
 
     describe "when the update fails", ->
       beforeEach ->
@@ -71,6 +66,7 @@ describe "Update Package Dependencies", ->
         exit(127)
 
       it "shows a failure message in the modal", ->
-        [modal] = atom.workspace.getModalPanels()
-        expect(modal.getItem().element.querySelector(".loading")).toBeNull()
-        expect(modal.getItem().element.textContent).toMatch(/Failed to update package dependencies/)
+        [notification] = atom.notifications.getNotifications()
+        expect(atom.workspace.getModalPanels().length).toEqual(0)
+        expect(notification.getType()).toEqual("error")
+        expect(notification.getMessage()).toEqual("Error!")

--- a/spec/update-package-dependencies-spec.coffee
+++ b/spec/update-package-dependencies-spec.coffee
@@ -65,7 +65,7 @@ describe "Update Package Dependencies", ->
         [{exit}] = mainModule.runBufferedProcess.argsForCall[0]
         exit(127)
 
-      it "shows a failure message in the modal", ->
+      it "shows a failure notification", ->
         [notification] = atom.notifications.getNotifications()
         expect(atom.workspace.getModalPanels().length).toEqual(0)
         expect(notification.getType()).toEqual("error")


### PR DESCRIPTION
### Description of the Change

This PR resolves the merge conflicts with https://github.com/atom/update-package-dependencies/pull/9 that have been introduced since that PR was opened.

Previously, when the update finished, the modal would show a success/failure message, but there was no way to dismiss the modal. Now, we automatically dismiss the modal and show a notification.

![notification](https://cloud.githubusercontent.com/assets/1551682/26222301/598b3c1e-3bce-11e7-8636-cf309dc82eb2.png)

### Alternate Designs

We could also keep the existing behavior where the modal's text updates, and just fix the ability to dismiss the modal.

### Benefits

The user is always going to want to dismiss the message, so a notification seems like an appropriate UI.

### Possible Drawbacks

This could be a tiny bit disruptive to people who are used to the old UI, but it seems unlikely since the old UI had a bug that prevented the modal from being dismissed.

### Applicable Issues

Fixes https://github.com/atom/update-package-dependencies/issues/10
Closes #9