### PR TITLE
Properly deactivate package and dispose of subscriptions

### DIFF
--- a/lib/update-package-dependencies.js
+++ b/lib/update-package-dependencies.js
@@ -3,7 +3,11 @@ const ProgressElement = require('./progress-element')
 
 module.exports = {
   activate () {
-    atom.commands.add('atom-workspace', 'update-package-dependencies:update', () => this.update())
+    this.subscription = atom.commands.add('atom-workspace', 'update-package-dependencies:update', () => this.update())
+  },
+
+  deactivate () {
+    this.subscription.dispose()
   },
 
   update () {
@@ -33,7 +37,7 @@ module.exports = {
   },
 
   runBufferedProcess (params) {
-    BufferedProcess(params)
+    new BufferedProcess(params) // eslint-disable-line no-new
   },
 
   getActiveProjectPath () {


### PR DESCRIPTION
Prevents the command still being active and able to be run even after the package itself is deactivated.

Also fixes a bug from #18.