### PR TITLE
Defer package activation

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,11 @@
   "engines": {
     "atom": ">0.39.0"
   },
+  "activationCommands": {
+    "atom-workspace": [
+      "update-package-dependencies:update"
+    ]
+  },
   "dependencies": {},
   "devDependencies": {
     "standard": "^10.0.3"


### PR DESCRIPTION
Only activate the package when `update-package-dependencies:update` is triggered.  As a side-effect of this change, calling `atom.packages.activatePackage('update-package-dependencies')` will no longer activate the package because activation is deferred.  Therefore, specs have been reorganized to test the module itself without needing to activate the whole package (though a spec has been added for that).