### PR TITLE
Cleanup

### DIFF
--- a/lib/update-package-dependencies.js
+++ b/lib/update-package-dependencies.js
@@ -15,7 +15,7 @@ module.exports = {
     const view = new ProgressElement()
     view.displayLoading()
     this.panel = atom.workspace.addModalPanel({item: view})
-    atom.commands.add(view.element, 'core:cancel', () => this.panel.destroy())
+    this.cancelSubscription = atom.commands.add('atom-workspace', 'core:cancel', () => this.panel.destroy())
 
     const command = atom.packages.getApmPath()
     const args = ['install']
@@ -23,6 +23,7 @@ module.exports = {
 
     const exit = code => {
       this.panel.destroy()
+      this.cancelSubscription.dispose()
 
       if (code === 0) {
         atom.notifications.addSuccess('Success!', {detail: 'Package dependencies updated.'})

--- a/lib/update-package-dependencies.js
+++ b/lib/update-package-dependencies.js
@@ -8,36 +8,35 @@ module.exports = {
 
   deactivate () {
     this.subscription.dispose()
+    if (this.panel) this.panel.destroy()
   },
 
   update () {
     const view = new ProgressElement()
     view.displayLoading()
-    const panel = atom.workspace.addModalPanel({item: view})
+    this.panel = atom.workspace.addModalPanel({item: view})
+    atom.commands.add(view.element, 'core:cancel', () => this.panel.destroy())
 
     const command = atom.packages.getApmPath()
     const args = ['install']
     const options = {cwd: this.getActiveProjectPath()}
 
     const exit = code => {
-      view.element.focus()
-
-      atom.commands.add(view.element, 'core:cancel', () => panel.destroy())
+      this.panel.destroy()
 
       if (code === 0) {
         atom.notifications.addSuccess('Success!', {detail: 'Package dependencies updated.'})
-        panel.destroy()
       } else {
         atom.notifications.addError('Error!', {detail: 'Failed to update package dependencies.'})
-        panel.destroy()
       }
     }
 
-    this.runBufferedProcess({command, args, exit, options})
+    this.process = this.runBufferedProcess({command, args, exit, options})
   },
 
+  // This function exists so that it can be spied on by tests
   runBufferedProcess (params) {
-    new BufferedProcess(params) // eslint-disable-line no-new
+    return new BufferedProcess(params)
   },
 
   getActiveProjectPath () {

--- a/spec/update-package-dependencies-spec.js
+++ b/spec/update-package-dependencies-spec.js
@@ -19,11 +19,11 @@ describe('Update Package Dependencies', () => {
       updatePackageDependencies.update()
 
       expect(updatePackageDependencies.runBufferedProcess).toHaveBeenCalled()
-      const [{command, args, options}] = updatePackageDependencies.runBufferedProcess.argsForCall[0]
+      const {command, args, options} = updatePackageDependencies.runBufferedProcess.argsForCall[0][0]
       if (process.platform !== 'win32') {
-        expect(command).toMatch(/\/apm$/)
+        expect(command.endsWith('/apm')).toBe(true)
       } else {
-        expect(command).toMatch(/\\apm.cmd$/)
+        expect(command.endsWith('\\apm.cmd')).toBe(true)
       }
       expect(args).toEqual(['install'])
       expect(options.cwd).toEqual(projectPath)
@@ -32,7 +32,7 @@ describe('Update Package Dependencies', () => {
     it('displays a progress modal', () => {
       updatePackageDependencies.update()
 
-      const [modal] = atom.workspace.getModalPanels()
+      const modal = atom.workspace.getModalPanels()[0]
       expect(modal.getItem().element.querySelector('.loading')).not.toBeNull()
       expect(modal.getItem().element.textContent).toMatch(/Updating package dependencies/)
     })
@@ -44,7 +44,7 @@ describe('Update Package Dependencies', () => {
         await atom.workspace.open(path.join(projectPath, 'package.json'))
 
         updatePackageDependencies.update()
-        const [{options}] = updatePackageDependencies.runBufferedProcess.argsForCall[0]
+        const {options} = updatePackageDependencies.runBufferedProcess.argsForCall[0][0]
         expect(options.cwd).toEqual(projectPath)
       })
     })
@@ -52,12 +52,12 @@ describe('Update Package Dependencies', () => {
     describe('when the update succeeds', () => {
       beforeEach(() => {
         updatePackageDependencies.update()
-        const [{exit}] = updatePackageDependencies.runBufferedProcess.argsForCall[0]
+        const {exit} = updatePackageDependencies.runBufferedProcess.argsForCall[0][0]
         exit(0)
       })
 
       it('shows a success notification message', () => {
-        const [notification] = atom.notifications.getNotifications()
+        const notification = atom.notifications.getNotifications()[0]
         expect(atom.workspace.getModalPanels().length).toEqual(0)
         expect(notification.getType()).toEqual('success')
         expect(notification.getMessage()).toEqual('Success!')
@@ -67,12 +67,12 @@ describe('Update Package Dependencies', () => {
     describe('when the update fails', () => {
       beforeEach(() => {
         updatePackageDependencies.update()
-        const [{exit}] = updatePackageDependencies.runBufferedProcess.argsForCall[0]
+        const {exit} = updatePackageDependencies.runBufferedProcess.argsForCall[0][0]
         exit(127)
       })
 
       it('shows a failure notification', () => {
-        const [notification] = atom.notifications.getNotifications()
+        const notification = atom.notifications.getNotifications()[0]
         expect(atom.workspace.getModalPanels().length).toEqual(0)
         expect(notification.getType()).toEqual('error')
         expect(notification.getMessage()).toEqual('Error!')


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

* Destroy modal panel when package is deactivated
* Allow `core:cancel` to destroy the modal as soon as it is created instead of registering the command right before the modal is destroyed...
* Clarify the existence of the `runBufferedProcess` helper function
* Remove excessive and potentially confusing array destructuring in specs

### Alternate Designs

I considered also killing the apm process on deactivation but that might lead to an inconsistent node_modules state.

### Benefits

Easier to follow code.

### Possible Drawbacks

None.

### Applicable Issues

None.