### PR TITLE
Install devDependencies as well

### DIFF
--- a/lib/update-package-dependencies.js
+++ b/lib/update-package-dependencies.js
@@ -19,7 +19,7 @@ module.exports = {
 
     const command = atom.packages.getApmPath()
     const args = ['install']
-    const options = {cwd: this.getActiveProjectPath()}
+    const options = {cwd: this.getActiveProjectPath(), env: Object.assign({}, process.env, {NODE_ENV: 'development'})}
 
     const exit = code => {
       this.panel.destroy()

--- a/spec/update-package-dependencies-spec.js
+++ b/spec/update-package-dependencies-spec.js
@@ -29,6 +29,13 @@ describe('Update Package Dependencies', () => {
       expect(options.cwd).toEqual(projectPath)
     })
 
+    it('sets NODE_ENV to development in order to install devDependencies', () => {
+      updatePackageDependencies.update()
+
+      const {options} = updatePackageDependencies.runBufferedProcess.argsForCall[0][0]
+      expect(options.env.NODE_ENV).toEqual('development')
+    })
+
     it('displays a progress modal', () => {
       updatePackageDependencies.update()
 


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

`NODE_ENV` needs to be set to `development` in order for dev dependencies to be installed.  So this PR assigns the existing `process.env` to a new object and then overwrites the new object's `NODE_ENV` with `'development'`.

### Alternate Designs

None.

### Benefits

All dependencies will be installed.

### Possible Drawbacks

Slower install time due to the extra time needed to install dev dependencies.

### Applicable Issues

None.