### PR TITLE
Only allow one apm process to run at a time

### DIFF
--- a/lib/update-package-dependencies.js
+++ b/lib/update-package-dependencies.js
@@ -19,6 +19,7 @@ module.exports = {
   },
 
   update () {
+    if (this.process) return // Do not allow multiple apm processes to run
     if (this.updatePackageDependenciesStatusView) this.updatePackageDependenciesStatusView.attach()
 
     const command = atom.packages.getApmPath()
@@ -26,6 +27,7 @@ module.exports = {
     const options = {cwd: this.getActiveProjectPath(), env: Object.assign({}, process.env, {NODE_ENV: 'development'})}
 
     const exit = code => {
+      this.process = null
       if (this.updatePackageDependenciesStatusView) this.updatePackageDependenciesStatusView.detach()
 
       if (code === 0) {

--- a/spec/update-package-dependencies-spec.js
+++ b/spec/update-package-dependencies-spec.js
@@ -13,13 +13,22 @@ describe('Update Package Dependencies', () => {
   })
 
   describe('updating package dependencies', () => {
-    beforeEach(() => spyOn(updatePackageDependencies, 'runBufferedProcess'))
+    let {command, args, exit, options} = {}
+    beforeEach(() => {
+      spyOn(updatePackageDependencies, 'runBufferedProcess').andCallFake((params) => {
+        ({command, args, exit, options} = params)
+        return true // so that this.process isn't null
+      })
+    })
+
+    afterEach(() => {
+      if (updatePackageDependencies.process) exit(0)
+    })
 
     it('runs the `apm install` command', () => {
       updatePackageDependencies.update()
 
       expect(updatePackageDependencies.runBufferedProcess).toHaveBeenCalled()
-      const {command, args, options} = updatePackageDependencies.runBufferedProcess.argsForCall[0][0]
       if (process.platform !== 'win32') {
         expect(command.endsWith('/apm')).toBe(true)
       } else {
@@ -29,10 +38,22 @@ describe('Update Package Dependencies', () => {
       expect(options.cwd).toEqual(projectPath)
     })
 
+    it('only allows one apm process to be spawned at a time', () => {
+      updatePackageDependencies.update()
+      expect(updatePackageDependencies.runBufferedProcess.callCount).toBe(1)
+
+      updatePackageDependencies.update()
+      updatePackageDependencies.update()
+      expect(updatePackageDependencies.runBufferedProcess.callCount).toBe(1)
+
+      exit(0)
+      updatePackageDependencies.update()
+      expect(updatePackageDependencies.runBufferedProcess.callCount).toBe(2)
+    })
+
     it('sets NODE_ENV to development in order to install devDependencies', () => {
       updatePackageDependencies.update()
 
-      const {options} = updatePackageDependencies.runBufferedProcess.argsForCall[0][0]
       expect(options.env.NODE_ENV).toEqual('development')
     })
 
@@ -45,9 +66,14 @@ describe('Update Package Dependencies', () => {
 
       mainModule.update()
 
-      const tile = statusBar.mainModule.statusBar.getRightTiles().find(tile => tile.item.matches('update-package-dependencies-status'))
+      let tile = statusBar.mainModule.statusBar.getRightTiles().find(tile => tile.item.matches('update-package-dependencies-status'))
       expect(tile.item.classList.contains('update-package-dependencies-status')).toBe(true)
       expect(tile.item.firstChild.classList.contains('loading')).toBe(true)
+
+      exit(0)
+
+      tile = statusBar.mainModule.statusBar.getRightTiles().find(tile => tile.item.matches('update-package-dependencies-status'))
+      expect(tile).toBeUndefined()
     })
 
     describe('when there are multiple project paths', () => {
@@ -57,7 +83,6 @@ describe('Update Package Dependencies', () => {
         await atom.workspace.open(path.join(projectPath, 'package.json'))
 
         updatePackageDependencies.update()
-        const {options} = updatePackageDependencies.runBufferedProcess.argsForCall[0][0]
         expect(options.cwd).toEqual(projectPath)
       })
     })
@@ -65,13 +90,11 @@ describe('Update Package Dependencies', () => {
     describe('when the update succeeds', () => {
       beforeEach(() => {
         updatePackageDependencies.update()
-        const {exit} = updatePackageDependencies.runBufferedProcess.argsForCall[0][0]
         exit(0)
       })
 
       it('shows a success notification message', () => {
         const notification = atom.notifications.getNotifications()[0]
-        expect(atom.workspace.getModalPanels().length).toEqual(0)
         expect(notification.getType()).toEqual('success')
         expect(notification.getMessage()).toEqual('Success!')
       })
@@ -80,13 +103,11 @@ describe('Update Package Dependencies', () => {
     describe('when the update fails', () => {
       beforeEach(() => {
         updatePackageDependencies.update()
-        const {exit} = updatePackageDependencies.runBufferedProcess.argsForCall[0][0]
         exit(127)
       })
 
       it('shows a failure notification', () => {
         const notification = atom.notifications.getNotifications()[0]
-        expect(atom.workspace.getModalPanels().length).toEqual(0)
         expect(notification.getType()).toEqual('error')
         expect(notification.getMessage()).toEqual('Error!')
       })


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

I'm not sure if a race condition is possible from running two or more apm processes simultaneously, but let's err on the safe side.

### Alternate Designs

None.

### Benefits

No duplicate apm processes or notifications.

### Possible Drawbacks

None.

### Applicable Issues

None.