### PR TITLE
Mark status bar tile as read-only

### DIFF
--- a/lib/update-package-dependencies-status-view.js
+++ b/lib/update-package-dependencies-status-view.js
@@ -3,7 +3,7 @@ class UpdatePackageDependenciesStatusView {
   constructor (statusBar) {
     this.statusBar = statusBar
     this.element = document.createElement('update-package-dependencies-status')
-    this.element.classList.add('update-package-dependencies-status', 'inline-block')
+    this.element.classList.add('update-package-dependencies-status', 'inline-block', 'is-read-only')
     this.spinner = document.createElement('span')
     this.spinner.classList.add('loading', 'loading-spinner-tiny', 'inline-block')
     this.element.appendChild(this.spinner)


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Minor UI change to prevent the new status bar tile from appearing to be 'clickable' (in the default One themes, this means that no hover background will be applied).

### Alternate Designs

None

### Benefits

Makes it more apparent that the spinner doesn't do anything when clicked

### Possible Drawbacks

None

### Applicable Issues

None